### PR TITLE
Rejects authentication when popup is closed manually

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,13 @@ class Trello {
         reject()
       }, 60000)
 
+      var popupTick = setInterval(function() {
+        if (popup.closed) {
+          clearInterval(popupTick);
+          reject();
+        }
+      }, 500);
+  
       window.addEventListener('message', e => {
         if (typeof e.data === 'string') {
           clearTimeout(timeout)

--- a/index.js
+++ b/index.js
@@ -16,13 +16,13 @@ class Trello {
 
       var timeout = setTimeout(() => {
         popup.close()
-        reject()
+        reject(new Error("Trello not authentified."))
       }, 60000)
 
       var popupTick = setInterval(function() {
         if (popup.closed) {
           clearInterval(popupTick);
-          reject();
+          reject(new Error("Trello not authentified."));
         }
       }, 500);
   


### PR DESCRIPTION
Auth promise didn't do anything if authentication popup is closed by the user before the 60 second timeout. This pull request will reject authentication in this case.

Additionally, an error message has been added on reject.